### PR TITLE
replace list with names

### DIFF
--- a/scripts/login-items
+++ b/scripts/login-items
@@ -7,7 +7,7 @@ usage: $(basename $0) command [args]
 
 Available commands:
     add                    add login items
-    list                   print login items names
+    names                  print login items names
     paths                  print login items paths
     rm                     remove login items
 
@@ -19,4 +19,3 @@ EOF
 [[ $1 == "-h" ]] || [[ $1 == "--help" ]] && usage "$@"
 
 "${BASH_SOURCE[0]%/*}"/"${BASH_SOURCE[0]##*/}"-"$1" "${@:2}"
-

--- a/scripts/login-items-rm
+++ b/scripts/login-items-rm
@@ -11,12 +11,11 @@ usage() {
 [[ $# == 0 ]] && usage
 
 while [[ $# != 0 ]]; do
-    login-items list | grep -q "$1" || echo "SKIP: $1 not found"
-    login-items list | grep -q "$1" && {
+    login-items names | grep -q "$1" || echo "SKIP: $1 not found"
+    login-items names | grep -q "$1" && {
     osascript <<EOF
 tell application "System Events" to delete login item "$1"
 EOF
     }
     shift
 done;:
-


### PR DESCRIPTION
I guess `list` command was replaced with the `names` one, but the `rm` command still references the old `list` command. This pull request should fix the issue.